### PR TITLE
Fixed dns package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fakegato-history": "^0.5.5",
     "moment": "^2.24.0",
     "utils": "^0.3.1",
-    "dns": "^0.0.1"
+    "dns": "^0.2.2"
   },
   "deprecated": false,
   "description": "Homebridge SMA Solar Inverter",


### PR DESCRIPTION
Hi your plugin is amazing. Just found out that your latest version has a dependency to dns 0.0.1 that doesn't exist on any npm...

``npm ERR! code ETARGET
npm ERR! notarget No matching version found for dns@^0.0.1
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.``