### PR TITLE
Bump `fakegato` from `^0.5.5` to `^0.6.1` since it includes https://github.com/simont77/fakegato-history/pull/105.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "bundleDependencies": false,
   "dependencies": {
-    "fakegato-history": "^0.5.5",
+    "fakegato-history": "^0.6.1",
     "modbus-serial": "^7.7.3",
     "moment": "^2.24.0",
     "utils": "^0.3.1"


### PR DESCRIPTION
Let's find out if this fixes https://github.com/codyc1515/homebridge-sma-inverter/issues/46?